### PR TITLE
MS-8038: avoid null to be cast to string 'null'

### DIFF
--- a/src/main/kotlin/org/taktik/icure/be/format/logic/impl/HealthOneLogicImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/be/format/logic/impl/HealthOneLogicImpl.kt
@@ -150,7 +150,7 @@ class HealthOneLogicImpl(
 	protected fun importProtocol(language: String, protoList: List<*>, position: Long, ril: ResultsInfosLine): org.taktik.icure.entities.embed.Service {
 		var text = (protoList[0] as ProtocolLine).text
 		for (i in 1 until protoList.size) {
-			text += "\n" + (protoList[i] as ProtocolLine).text
+			text += "\n" + ((protoList[i] as ProtocolLine).text ?: "")
 		}
 		val s = org.taktik.icure.entities.embed.Service(
 			id = uuidGen.newGUID().toString(),


### PR DESCRIPTION
.text -> null is cast to "null", this correction avoids this