### PR TITLE
Add support for fake object storage implementation

### DIFF
--- a/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/impl/LocalObjectStorageImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/impl/LocalObjectStorageImpl.kt
@@ -12,7 +12,6 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
@@ -20,9 +19,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
-import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.DisposableBean
 import org.springframework.beans.factory.InitializingBean
@@ -37,12 +34,12 @@ import org.taktik.icure.entities.base.HasDataAttachments
 import org.taktik.icure.properties.ObjectStorageProperties
 import org.taktik.icure.utils.toByteArray
 
-interface ScheduledLocalObjectStorage<T : HasDataAttachments<T>> : LocalObjectStorage<T>, DisposableBean, InitializingBean
+interface LocalObjectStorageBean<T : HasDataAttachments<T>> : LocalObjectStorage<T>, DisposableBean, InitializingBean
 
 private class LocalObjectStorageImpl<T : HasDataAttachments<T>>(
 	private val objectStorageProperties: ObjectStorageProperties,
 	private val entityPath: String
-) : ScheduledLocalObjectStorage<T> {
+) : LocalObjectStorageBean<T> {
 	companion object {
 		private val log = LoggerFactory.getLogger(LocalObjectStorageImpl::class.java)
 	}
@@ -167,7 +164,7 @@ private class LocalObjectStorageImpl<T : HasDataAttachments<T>>(
 @Service
 class DocumentLocalObjectStorageImpl(
 	objectStorageProperties: ObjectStorageProperties
-) : DocumentLocalObjectStorage, ScheduledLocalObjectStorage<Document> by LocalObjectStorageImpl(
+) : DocumentLocalObjectStorage, LocalObjectStorageBean<Document> by LocalObjectStorageImpl(
 	objectStorageProperties,
 	"documents"
 )

--- a/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/impl/ObjectStorageClientImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/impl/ObjectStorageClientImpl.kt
@@ -1,6 +1,7 @@
 package org.taktik.icure.asynclogic.objectstorage.impl
 
 import java.io.Serializable
+import java.lang.IllegalArgumentException
 import java.net.URI
 import java.net.URISyntaxException
 import java.util.Base64
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.reactive.asPublisher
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.InitializingBean
 import org.springframework.core.io.buffer.DataBuffer
 import org.springframework.core.io.buffer.DefaultDataBufferFactory
 import org.springframework.http.HttpHeaders
@@ -46,7 +48,7 @@ private class ObjectStorageClientImpl<T : HasDataAttachments<T>>(
 	private val objectStorageProperties: ObjectStorageProperties,
 	private val cloudAuthenticationLogic: CloudAuthenticationLogic,
 	override val entityGroupName: String
-) : ObjectStorageClient<T> {
+) : ObjectStorageClient<T>, InitializingBean {
 	companion object {
 		private const val NEXT_BYTE_HEADER = "Next-Byte"
 		private val log = LoggerFactory.getLogger(ObjectStorageClientImpl::class.java)
@@ -59,6 +61,16 @@ private class ObjectStorageClientImpl<T : HasDataAttachments<T>>(
 			.build()
 	}
 	private val nextBytesMap = ConcurrentHashMap<Pair<String, String>, Int>()
+
+	override fun afterPropertiesSet() {
+		val icureCloudUrl = objectStorageProperties.icureCloudUrl
+		try {
+			require(icureCloudUrl.isNotBlank()) { "icureCloudUrl can't be blank" }
+			URI(icureCloudUrl)
+		} catch (e: URISyntaxException) {
+			throw IllegalArgumentException("icureCloudUrl=\"$icureCloudUrl\" must be a valid uri", e)
+		}
+	}
 
 	override suspend fun upload(entity: T, attachmentId: String, content: Flow<DataBuffer>, userId: String): Boolean =
 		unsafeUpload(entity.id, attachmentId, content, userId)

--- a/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/impl/ObjectStorageClientImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/impl/ObjectStorageClientImpl.kt
@@ -43,12 +43,14 @@ import org.taktik.icure.properties.ObjectStorageProperties
 import org.taktik.icure.utils.toByteArray
 import reactor.core.publisher.Mono
 
+interface ObjectStorageClientBean<T : HasDataAttachments<T>> : ObjectStorageClient<T>, InitializingBean {}
+
 @OptIn(ExperimentalCoroutinesApi::class)
 private class ObjectStorageClientImpl<T : HasDataAttachments<T>>(
 	private val objectStorageProperties: ObjectStorageProperties,
 	private val cloudAuthenticationLogic: CloudAuthenticationLogic,
 	override val entityGroupName: String
-) : ObjectStorageClient<T>, InitializingBean {
+) : ObjectStorageClientBean<T> {
 	companion object {
 		private const val NEXT_BYTE_HEADER = "Next-Byte"
 		private val log = LoggerFactory.getLogger(ObjectStorageClientImpl::class.java)
@@ -197,7 +199,7 @@ private class ObjectStorageClientImpl<T : HasDataAttachments<T>>(
 class DocumentObjectStorageClientImpl(
 	objectStorageProperties: ObjectStorageProperties,
 	cloudAuthenticationLogic: CloudAuthenticationLogic
-) : DocumentObjectStorageClient, ObjectStorageClient<Document> by ObjectStorageClientImpl(
+) : DocumentObjectStorageClient, ObjectStorageClientBean<Document> by ObjectStorageClientImpl(
 	objectStorageProperties,
 	cloudAuthenticationLogic,
 	"documents"

--- a/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/impl/fake/FakeObjectStorageClient.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/impl/fake/FakeObjectStorageClient.kt
@@ -1,44 +1,70 @@
 package org.taktik.icure.asynclogic.objectstorage.impl.fake
 
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.channels.AsynchronousFileChannel
+import java.nio.file.Files
+import java.util.UUID
+import kotlin.random.Random
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.withContext
 import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.core.io.buffer.DataBufferUtils
 import org.springframework.core.io.buffer.DefaultDataBufferFactory
 import org.taktik.icure.asynclogic.objectstorage.DocumentObjectStorageClient
 import org.taktik.icure.asynclogic.objectstorage.ObjectStorageClient
 import org.taktik.icure.entities.base.HasDataAttachments
 import org.taktik.icure.asynclogic.objectstorage.ObjectStorageException
 import org.taktik.icure.entities.Document
+import org.taktik.icure.properties.ExternalServicesProperties
 import org.taktik.icure.utils.toByteArray
 
 /**
  * Fake implementation of [ObjectStorageClient], for testing purposes only (including creation of a test container).
  * @param entityGroupName group name of entities supported by this object storage client (e.g. documents)
+ * @param externalServicesProperties properties of external services for the application.
+ * @param eventsChannel if not null methods invoked on this implementation will be logged to the event channel.
  * @param checkUser verifies if a user can actually use this client, for testing purposes.
  */
 class FakeObjectStorageClient<T : HasDataAttachments<T>>(
 	override val entityGroupName: String,
+	externalServicesProperties: ExternalServicesProperties,
+	private val eventsChannel: Channel<ObjectStoreEvent>?,
 	private val checkUser: (String) -> Boolean
 ) : ObjectStorageClient<T> {
 	companion object {
 		/**
 		 * Creates a fake [DocumentObjectStorageClient], using a [FakeObjectStorageClient] as base for the implementation.
-		 * @param checkUser see [FakeObjectStorageClient.checkUser]
+		 * @param externalServicesProperties see [FakeObjectStorageClient]'s constructor
+		 * @param eventsChannel see [FakeObjectStorageClient]'s constructor
+		 * @param checkUser see [FakeObjectStorageClient]'s constructor
 		 */
-		fun document(checkUser: (String) -> Boolean): DocumentObjectStorageClient =
+		fun document(
+			externalServicesProperties: ExternalServicesProperties,
+			eventsChannel: Channel<ObjectStoreEvent>?,
+			checkUser: (String) -> Boolean
+		): DocumentObjectStorageClient =
 			object : DocumentObjectStorageClient, ObjectStorageClient<Document> by FakeObjectStorageClient(
 				"documents",
+				externalServicesProperties,
+				eventsChannel,
 				checkUser
 			) {}
 	}
 
 	var available = true
 
-	val eventsChannel = Channel<ObjectStoreEvent>(UNLIMITED)
-
-	private val entityToAttachments = mutableMapOf<String, MutableMap<String, ByteArray>>()
+	private val storageDirectory = if (!externalServicesProperties.storeFakeObjectStorageInRam) {
+		Files.createTempDirectory("icure-fakeobjectstorage-").toFile().also { it.deleteOnExit() }
+	} else null
+	// Currently there is no need for thread safety, since the object storage implementation should ensure only one store/delete
+	// operation is executed at a time
+	private val entityToAttachments = mutableMapOf<String, MutableMap<String, StoredData>>()
 
 	val attachmentsKeys get() = entityToAttachments.flatMap { (docId, attachments) -> attachments.keys.map { docId to it } }
 
@@ -48,11 +74,31 @@ class FakeObjectStorageClient<T : HasDataAttachments<T>>(
 	override suspend fun unsafeUpload(entityId: String, attachmentId: String, content: Flow<DataBuffer>, userId: String): Boolean {
 		checkUser(userId)
 		return if (available) {
-			entityToAttachments.computeIfAbsent(entityId) { mutableMapOf() }.putIfAbsent(attachmentId, content.toByteArray(true))
-			eventsChannel.send(ObjectStoreEvent(entityId, attachmentId, ObjectStoreEvent.Type.SUCCESSFUL_UPLOAD))
+			val entityAttachments = entityToAttachments.computeIfAbsent(entityId) { mutableMapOf() }
+			if (!entityAttachments.containsKey(attachmentId)) {
+				val storedObject = storageDirectory?.let { dir ->
+					val objSubdir = Random.nextInt(255).toString()
+					val objUUID = UUID.randomUUID().toString()
+					val objFile = dir.resolve(objSubdir).also { it.mkdir() }.resolve(objUUID)
+					withContext(Dispatchers.IO) {
+						RandomAccessFile(objFile, "rw").channel.use { channel ->
+							content.collect {
+								it.asByteBuffer().let { byteBuffer ->
+									while (byteBuffer.hasRemaining()) {
+										channel.write(byteBuffer)
+									}
+								}
+							}
+						}
+					}
+					StoredData.Filesystem(objFile)
+				} ?: StoredData.Ram(content.toByteArray(true))
+				entityAttachments[attachmentId] = storedObject
+			}
+			eventsChannel?.send(ObjectStoreEvent(entityId, attachmentId, ObjectStoreEvent.Type.SUCCESSFUL_UPLOAD))
 			true
 		} else {
-			eventsChannel.send(ObjectStoreEvent(entityId, attachmentId, ObjectStoreEvent.Type.UNSUCCESSFUL_UPLOAD))
+			eventsChannel?.send(ObjectStoreEvent(entityId, attachmentId, ObjectStoreEvent.Type.UNSUCCESSFUL_UPLOAD))
 			false
 		}
 	}
@@ -60,7 +106,7 @@ class FakeObjectStorageClient<T : HasDataAttachments<T>>(
 	override fun get(entity: T, attachmentId: String, userId: String): Flow<DataBuffer> {
 		checkUser(userId)
 		return if (available) {
-			entityToAttachments[entity.id]?.get(attachmentId)?.let { flowOf(DefaultDataBufferFactory.sharedInstance.wrap(it)) }
+			entityToAttachments[entity.id]?.get(attachmentId)?.asFlow()
 				?: throw IllegalStateException("Document does not exist. Available attachments: $attachmentsKeys")
 		} else throw ObjectStorageException("Storage service is unavailable", null)
 	}
@@ -79,15 +125,33 @@ class FakeObjectStorageClient<T : HasDataAttachments<T>>(
 		checkUser(userId)
 		return if (available) {
 			entityToAttachments[entityId]?.remove(attachmentId)
-			eventsChannel.send(ObjectStoreEvent(entityId, attachmentId, ObjectStoreEvent.Type.SUCCESSFUL_DELETE))
+			eventsChannel?.send(ObjectStoreEvent(entityId, attachmentId, ObjectStoreEvent.Type.SUCCESSFUL_DELETE))
 			true
 		} else {
-			eventsChannel.send(ObjectStoreEvent(entityId, attachmentId, ObjectStoreEvent.Type.UNSUCCESSFUL_DELETE))
+			eventsChannel?.send(ObjectStoreEvent(entityId, attachmentId, ObjectStoreEvent.Type.UNSUCCESSFUL_DELETE))
 			false
 		}
 	}
 
 	data class ObjectStoreEvent(val documentId: String, val attachmentId: String, val type: Type) {
 		enum class Type { SUCCESSFUL_UPLOAD, SUCCESSFUL_DELETE, UNSUCCESSFUL_UPLOAD, UNSUCCESSFUL_DELETE }
+	}
+
+	sealed class StoredData {
+		abstract fun asFlow(): Flow<DataBuffer>
+
+		class Ram(val data: ByteArray): StoredData() {
+			override fun asFlow(): Flow<DataBuffer> =
+				flowOf(DefaultDataBufferFactory.sharedInstance.wrap(data))
+		}
+		class Filesystem(val file: File): StoredData() {
+			override fun asFlow(): Flow<DataBuffer> =
+				DataBufferUtils.readAsynchronousFileChannel(
+					{ AsynchronousFileChannel.open(file.toPath()) },
+					0,
+					DefaultDataBufferFactory.sharedInstance,
+					10000
+				).asFlow()
+		}
 	}
 }

--- a/src/main/kotlin/org/taktik/icure/asynclogic/utils/CloudAuthenticationLogic.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/utils/CloudAuthenticationLogic.kt
@@ -1,12 +1,13 @@
 package org.taktik.icure.asynclogic.utils
 
 /**
- * Logic for authentication from the current instance of icure-oss to icure-cloud
+ * Logic for authentication from the current instance of icure-oss to icure-cloud.
+ * Implementations of this interface may have additional requirements in order for
+ * everything to work properly.
  */
 interface CloudAuthenticationLogic {
 	/**
 	 * Get the value of an authorization header for authentication to the icure cloud as the user with the provided id.
-	 * The header will only be valid if the
 	 * @param userId id of the user you want to authenticate as.
 	 * @return the authorization header value for the user.
 	 */

--- a/src/main/kotlin/org/taktik/icure/asynclogic/utils/impl/CloudAuthenticationLogicImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/utils/impl/CloudAuthenticationLogicImpl.kt
@@ -13,6 +13,11 @@ import org.taktik.icure.asynclogic.UserLogic
 import org.taktik.icure.asynclogic.utils.CloudAuthenticationLogic
 import org.taktik.icure.asynclogic.utils.InstallationConstantLogic
 
+/**
+ * Implementation of [CloudAuthenticationLogic] which uses iCure authentication tokens.
+ * This implementation only works if the synchronisation between the local couchdb instance
+ * and the cloud couchdb instance is properly set up.
+ */
 @Service
 class CloudAuthenticationLogicImpl(
 	private val installationConstantLogic: InstallationConstantLogic,

--- a/src/main/kotlin/org/taktik/icure/config/ObjectStorageConfig.kt
+++ b/src/main/kotlin/org/taktik/icure/config/ObjectStorageConfig.kt
@@ -25,7 +25,11 @@ class ObjectStorageConfig {
 	): DocumentObjectStorageClient =
 		if (externalServicesProperties.useFakes) {
 			log.warn("Using fake object storage client. This should be done only for testing purposes.")
-			FakeObjectStorageClient.document(fakeObjectStorageClientUserCheck ?: { true })
+			FakeObjectStorageClient.document(
+				externalServicesProperties,
+				null,
+				fakeObjectStorageClientUserCheck ?: { true }
+			)
 		} else {
 			DocumentObjectStorageClientImpl(objectStorageProperties, cloudAuthenticationLogic)
 		}

--- a/src/main/kotlin/org/taktik/icure/config/ObjectStorageConfig.kt
+++ b/src/main/kotlin/org/taktik/icure/config/ObjectStorageConfig.kt
@@ -1,19 +1,32 @@
 package org.taktik.icure.config
 
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.taktik.icure.asynclogic.AsyncSessionLogic
 import org.taktik.icure.asynclogic.objectstorage.DocumentObjectStorageClient
 import org.taktik.icure.asynclogic.objectstorage.impl.DocumentObjectStorageClientImpl
+import org.taktik.icure.asynclogic.objectstorage.impl.fake.FakeObjectStorageClient
 import org.taktik.icure.asynclogic.utils.CloudAuthenticationLogic
+import org.taktik.icure.properties.ExternalServicesProperties
 import org.taktik.icure.properties.ObjectStorageProperties
 
 @Configuration
 class ObjectStorageConfig {
+	private val log = LoggerFactory.getLogger(ObjectStorageConfig::class.java)
+
 	@Bean
 	fun documentObjectStorageClient(
-		properties: ObjectStorageProperties,
-		cloudAuthenticationLogic: CloudAuthenticationLogic
+		objectStorageProperties: ObjectStorageProperties,
+		cloudAuthenticationLogic: CloudAuthenticationLogic,
+		externalServicesProperties: ExternalServicesProperties,
+		@Autowired(required=false) @Qualifier("fakeObjectStorageClientUserCheck") fakeObjectStorageClientUserCheck: ((String) -> Boolean)?
 	): DocumentObjectStorageClient =
-		DocumentObjectStorageClientImpl(properties, cloudAuthenticationLogic)
+		if (externalServicesProperties.useFakes) {
+			log.warn("Using fake object storage client. This should be done only for testing purposes.")
+			FakeObjectStorageClient.document(fakeObjectStorageClientUserCheck ?: { true })
+		} else {
+			DocumentObjectStorageClientImpl(objectStorageProperties, cloudAuthenticationLogic)
+		}
 }

--- a/src/main/kotlin/org/taktik/icure/properties/ExternalServicesProperties.kt
+++ b/src/main/kotlin/org/taktik/icure/properties/ExternalServicesProperties.kt
@@ -15,5 +15,9 @@ data class ExternalServicesProperties(
 	 * If true uses fake in-memory implementations of external services instead of doing requests to real services.
 	 * This simplifies the creation of isolated test environments.
 	 */
-	var useFakes: Boolean = false
+	var useFakes: Boolean = false,
+	/**
+	 * Specifies if the data of the fake ObjectStorageClient should be stored in ram (true) or in a temporary directory on the file system (false).
+	 */
+	var storeFakeObjectStorageInRam: Boolean = false
 )

--- a/src/main/kotlin/org/taktik/icure/properties/ExternalServicesProperties.kt
+++ b/src/main/kotlin/org/taktik/icure/properties/ExternalServicesProperties.kt
@@ -1,0 +1,19 @@
+package org.taktik.icure.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+
+/**
+ * Properties for external services such as icure-cloud for object storage.
+ */
+@Component
+@Profile("app")
+@ConfigurationProperties("icure.externalservices")
+data class ExternalServicesProperties(
+	/**
+	 * If true uses fake in-memory implementations of external services instead of doing requests to real services.
+	 * This simplifies the creation of isolated test environments.
+	 */
+	var useFakes: Boolean = false
+)

--- a/src/main/kotlin/org/taktik/icure/properties/ObjectStorageProperties.kt
+++ b/src/main/kotlin/org/taktik/icure/properties/ObjectStorageProperties.kt
@@ -41,14 +41,5 @@ final data class ObjectStorageProperties(
 		require(migrationSizeLimit >= sizeLimit) {
 			"Migration size limit must be greater than or equal to sizeLimit"
 		}
-		try {
-			require(icureCloudUrl.isNotBlank()) { "icureCloudUrl can't be blank" }
-			URI(icureCloudUrl)
-		} catch (e: URISyntaxException) {
-			throw IllegalArgumentException("icureCloudUrl=\"$icureCloudUrl\" must be a valid uri", e)
-		}
-		require(cacheLocation.isNotBlank() && File(cacheLocation).also { it.mkdirs() }.let { it.isDirectory && it.canRead() && it.canWrite() }) {
-			"cacheLocation=\"$cacheLocation\" must be a folder where the icure application has read/write access"
-		}
 	}
 }

--- a/src/test/kotlin/org/taktik/icure/asynclogic/objectstorage/IcureObjectStorageMigrationTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/objectstorage/IcureObjectStorageMigrationTest.kt
@@ -40,6 +40,7 @@ import org.taktik.icure.asynclogic.objectstorage.testutils.testObjectStorageProp
 import org.taktik.icure.entities.Document
 import org.taktik.icure.entities.embed.DeletedAttachment
 import org.taktik.icure.entities.objectstorage.ObjectStorageMigrationTask
+import org.taktik.icure.properties.ExternalServicesProperties
 import org.taktik.icure.test.newId
 import org.taktik.icure.test.setCurrentUserData
 
@@ -63,7 +64,11 @@ class IcureObjectStorageMigrationTest : StringSpec({
 		sessionLogic.setCurrentUserData(userId)
 		resetTestLocalStorageDirectory()
 		documentDAO = mockk()
-		objectStorageClient = FakeObjectStorageClient("documents") { it == userId }
+		objectStorageClient = FakeObjectStorageClient(
+			"documents",
+			ExternalServicesProperties(true, true),
+			null
+		) { it == userId }
 		storageTasksDAO = FakeObjectStorageTasksDAO()
 		migrationTasksDAO = FakeObjectStorageMigrationTasksDAO()
 		icureObjectStorage = DocumentObjectStorageImpl(

--- a/src/test/kotlin/org/taktik/icure/asynclogic/objectstorage/IcureObjectStorageMigrationTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/objectstorage/IcureObjectStorageMigrationTest.kt
@@ -27,7 +27,7 @@ import org.taktik.icure.asynclogic.AsyncSessionLogic
 import org.taktik.icure.asynclogic.objectstorage.impl.DocumentLocalObjectStorageImpl
 import org.taktik.icure.asynclogic.objectstorage.impl.DocumentObjectStorageImpl
 import org.taktik.icure.asynclogic.objectstorage.impl.DocumentObjectStorageMigrationImpl
-import org.taktik.icure.asynclogic.objectstorage.testutils.FakeObjectStorageClient
+import org.taktik.icure.asynclogic.objectstorage.impl.fake.FakeObjectStorageClient
 import org.taktik.icure.asynclogic.objectstorage.testutils.FakeObjectStorageMigrationTasksDAO
 import org.taktik.icure.asynclogic.objectstorage.testutils.FakeObjectStorageTasksDAO
 import org.taktik.icure.asynclogic.objectstorage.testutils.attachment1
@@ -36,12 +36,10 @@ import org.taktik.icure.asynclogic.objectstorage.testutils.bytes1
 import org.taktik.icure.asynclogic.objectstorage.testutils.bytes2
 import org.taktik.icure.asynclogic.objectstorage.testutils.document1
 import org.taktik.icure.asynclogic.objectstorage.testutils.resetTestLocalStorageDirectory
-import org.taktik.icure.asynclogic.objectstorage.testutils.testLocalStorageDirectory
 import org.taktik.icure.asynclogic.objectstorage.testutils.testObjectStorageProperties
 import org.taktik.icure.entities.Document
 import org.taktik.icure.entities.embed.DeletedAttachment
 import org.taktik.icure.entities.objectstorage.ObjectStorageMigrationTask
-import org.taktik.icure.properties.ObjectStorageProperties
 import org.taktik.icure.test.newId
 import org.taktik.icure.test.setCurrentUserData
 
@@ -65,7 +63,7 @@ class IcureObjectStorageMigrationTest : StringSpec({
 		sessionLogic.setCurrentUserData(userId)
 		resetTestLocalStorageDirectory()
 		documentDAO = mockk()
-		objectStorageClient = FakeObjectStorageClient("documents", setOf(userId))
+		objectStorageClient = FakeObjectStorageClient("documents") { it == userId }
 		storageTasksDAO = FakeObjectStorageTasksDAO()
 		migrationTasksDAO = FakeObjectStorageMigrationTasksDAO()
 		icureObjectStorage = DocumentObjectStorageImpl(

--- a/src/test/kotlin/org/taktik/icure/asynclogic/objectstorage/IcureObjectStorageTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/objectstorage/IcureObjectStorageTest.kt
@@ -18,8 +18,8 @@ import org.taktik.icure.asyncdao.objectstorage.ObjectStorageTasksDAO
 import org.taktik.icure.asynclogic.AsyncSessionLogic
 import org.taktik.icure.asynclogic.objectstorage.impl.DocumentLocalObjectStorageImpl
 import org.taktik.icure.asynclogic.objectstorage.impl.DocumentObjectStorageImpl
-import org.taktik.icure.asynclogic.objectstorage.testutils.FakeObjectStorageClient
-import org.taktik.icure.asynclogic.objectstorage.testutils.FakeObjectStorageClient.ObjectStoreEvent
+import org.taktik.icure.asynclogic.objectstorage.impl.fake.FakeObjectStorageClient
+import org.taktik.icure.asynclogic.objectstorage.impl.fake.FakeObjectStorageClient.ObjectStoreEvent
 import org.taktik.icure.asynclogic.objectstorage.testutils.FakeObjectStorageTasksDAO
 import org.taktik.icure.asynclogic.objectstorage.testutils.attachment1
 import org.taktik.icure.asynclogic.objectstorage.testutils.attachment2
@@ -28,12 +28,10 @@ import org.taktik.icure.asynclogic.objectstorage.testutils.bytes2
 import org.taktik.icure.asynclogic.objectstorage.testutils.document1
 import org.taktik.icure.asynclogic.objectstorage.testutils.resetTestLocalStorageDirectory
 import org.taktik.icure.asynclogic.objectstorage.testutils.sampleAttachments
-import org.taktik.icure.asynclogic.objectstorage.testutils.testLocalStorageDirectory
 import org.taktik.icure.asynclogic.objectstorage.testutils.testObjectStorageProperties
 import org.taktik.icure.entities.Document
 import org.taktik.icure.entities.objectstorage.ObjectStorageTask
 import org.taktik.icure.entities.objectstorage.ObjectStorageTaskType
-import org.taktik.icure.properties.ObjectStorageProperties
 import org.taktik.icure.test.newId
 import org.taktik.icure.test.setCurrentUserData
 import org.taktik.icure.test.shouldContainExactly
@@ -55,7 +53,7 @@ class IcureObjectStorageTest : StringSpec({
 		userId = newId()
 		sessionLogic.setCurrentUserData(userId)
 		resetTestLocalStorageDirectory()
-		objectStorageClient = FakeObjectStorageClient("documents", setOf(userId))
+		objectStorageClient = FakeObjectStorageClient("documents") { it == userId }
 		storageTasksDAO = FakeObjectStorageTasksDAO()
 		icureObjectStorage = DocumentObjectStorageImpl(
 			storageTasksDAO,

--- a/src/test/kotlin/org/taktik/icure/test/ICureTestApplication.kt
+++ b/src/test/kotlin/org/taktik/icure/test/ICureTestApplication.kt
@@ -29,7 +29,7 @@ import org.taktik.icure.asynclogic.PropertyLogic
 import org.taktik.icure.asynclogic.UserLogic
 import org.taktik.icure.asynclogic.objectstorage.DocumentObjectStorageClient
 import org.taktik.icure.asynclogic.objectstorage.ObjectStorageClient
-import org.taktik.icure.asynclogic.objectstorage.testutils.FakeObjectStorageClient
+import org.taktik.icure.asynclogic.objectstorage.impl.fake.FakeObjectStorageClient
 import org.taktik.icure.constants.Users
 import org.taktik.icure.entities.Document
 import org.taktik.icure.exceptions.DuplicateDocumentException
@@ -133,12 +133,14 @@ class ICureTestApplication {
 	}
 
 	// Test beans
-	@Primary
-	@Bean
-	fun fakeDocumentObjectStorageClient(userLogic: UserLogic): DocumentObjectStorageClient {
-		val fakeClient = FakeObjectStorageClient<Document>(
-			"documents"
-		) { runBlocking { setOf(userLogic.getUserByLogin(System.getenv("ICURE_TEST_USER_NAME"))!!.id) } }
-		return object : DocumentObjectStorageClient, ObjectStorageClient<Document> by fakeClient {}
+	@Bean("fakeObjectStorageClientUserCheck")
+	fun fakeObjectStorageClientUserCheck(userLogic: UserLogic): (String) -> Boolean {
+		return object : (String) -> Boolean {
+			private val expectedId by lazy {
+				runBlocking { userLogic.getUserByLogin(System.getenv("ICURE_TEST_USER_NAME"))!!.id }
+			}
+
+			override fun invoke(userId: String): Boolean = userId == expectedId
+		}
 	}
 }

--- a/src/test/resources/icure-test.properties
+++ b/src/test/resources/icure-test.properties
@@ -43,3 +43,4 @@ icure.mikrono.server=https://mikrono.svcacc.icure.cloud
 icure.mikrono.superuser=icure
 icure.mikrono.supertoken=751fcf8b-aad1-4b14-a2b7-3345dd33727f
 icure.mikrono.applicationtoken=L7FSRAGFROE20A66J3K2XVOZIIIKSELZZDS9D
+icure.externalservices.useFakes=true


### PR DESCRIPTION
Enable with `icure.externalservices.useFakes=true`