### PR TITLE
EHR-86 Added Lenient serializer for collections

### DIFF
--- a/src/main/kotlin/org/taktik/icure/entities/HealthcareParty.kt
+++ b/src/main/kotlin/org/taktik/icure/entities/HealthcareParty.kt
@@ -20,6 +20,7 @@ package org.taktik.icure.entities
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.github.pozo.KotlinBuilder
 import org.taktik.couchdb.entity.Attachment
 import org.taktik.icure.entities.base.CodeStub
@@ -42,6 +43,7 @@ import org.taktik.icure.entities.embed.PersonName
 import org.taktik.icure.entities.embed.RevisionInfo
 import org.taktik.icure.entities.embed.TelecomType
 import org.taktik.icure.entities.utils.MergeUtil.mergeListsDistinct
+import org.taktik.icure.handlers.JacksonLenientCollectionDeserializer
 import org.taktik.icure.utils.DynamicInitializer
 import org.taktik.icure.utils.invoke
 import org.taktik.icure.validation.AutoFix
@@ -138,7 +140,7 @@ data class HealthcareParty(
 	val statuses: Set<HealthcarePartyStatus> = emptySet(),
 	val statusHistory: List<HealthcarePartyHistoryStatus> = emptyList(),
 	val descr: Map<String, String>? = emptyMap(),
-	@field:ValidCode(autoFix = AutoFix.NORMALIZECODE) val specialityCodes: Set<CodeStub> = emptySet(), //Speciality codes, default is first
+	@field:ValidCode(autoFix = AutoFix.NORMALIZECODE) @JsonDeserialize(using = JacksonLenientCollectionDeserializer::class) val specialityCodes: Set<CodeStub> = emptySet(), //Speciality codes, default is first
 
 	val sendFormats: Map<TelecomType, String> = emptyMap(),
 	val notes: String? = null,

--- a/src/main/kotlin/org/taktik/icure/handlers/JacksonLenientCollectionDeserializer.kt
+++ b/src/main/kotlin/org/taktik/icure/handlers/JacksonLenientCollectionDeserializer.kt
@@ -1,0 +1,39 @@
+package org.taktik.icure.handlers
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.BeanProperty
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer
+import com.fasterxml.jackson.databind.node.ArrayNode
+
+class JacksonLenientCollectionDeserializer(
+	private val collectionType: JavaType? = null,
+	val elementType: JavaType? = null
+) : JsonDeserializer<Collection<*>>(), ContextualDeserializer {
+
+	val mapper: ObjectMapper by lazy { ObjectMapper() }
+
+	override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Collection<*> {
+		return p.readValueAsTree<ArrayNode>()
+			.filter { !it.isNull }
+			.map {
+				mapper.treeToValue(it, elementType?.rawClass)
+			}.let {
+				when(collectionType?.rawClass?.simpleName) {
+					"Set" -> it.toSet()
+					"List" -> it.toList()
+					else -> it
+				}
+			}
+	}
+
+	override fun createContextual(ctxt: DeserializationContext?, property: BeanProperty?): JsonDeserializer<*> {
+		return JacksonLenientCollectionDeserializer(
+			property?.type,
+			property?.type?.containedType(0)
+		)
+	}
+}


### PR DESCRIPTION
This serializer can remove null values from Collections of non-nullable types.
Currently is only active on the specialtyCodes field of the healthcare party