### PR TITLE
Secondary attachment methods in controller do not allow to use main attachment key

### DIFF
--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/DocumentController.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/DocumentController.kt
@@ -422,7 +422,12 @@ class DocumentController(
 			"Attachment size must be specified in the content-length header"
 		)
 		documentLogic.updateAttachmentsWrappingExceptions(
-			documentLogic.getOr404(documentId).also { checkRevision(rev, it) },
+			documentLogic.getOr404(documentId).also {
+				checkRevision(rev, it)
+				require(key != it.mainAttachmentKey) {
+					"Secondary attachments can't use $key as key: this key is reserved for the main attachment."
+				}
+			},
 			secondaryAttachmentsChanges = mapOf(
 				key to DataAttachmentChange.CreateOrUpdate(
 					payload,
@@ -446,7 +451,11 @@ class DocumentController(
 		response: ServerHttpResponse
 	) = response.writeWith(
 		flow {
-			val document = documentLogic.getOr404(documentId)
+			val document = documentLogic.getOr404(documentId).also {
+				require(key != it.mainAttachmentKey) {
+					"Secondary attachments can't use $key as key: this key is reserved for the main attachment."
+				}
+			}
 			val attachment = attachmentLoader.contentFlowOfNullable(document, key) ?: throw ResponseStatusException(
 				HttpStatus.NOT_FOUND,
 				"No secondary attachment with key $key for document $documentId"
@@ -471,7 +480,12 @@ class DocumentController(
 		rev: String,
 	): Mono<DocumentDto> = mono {
 		documentLogic.updateAttachments(
-			documentLogic.getOr404(documentId).also { checkRevision(rev, it) },
+			documentLogic.getOr404(documentId).also {
+				checkRevision(rev, it)
+				require(key != it.mainAttachmentKey) {
+					"Secondary attachments can't use $key as key: this key is reserved for the main attachment."
+				}
+			},
 			secondaryAttachmentsChanges = mapOf(key to DataAttachmentChange.Delete)
 		).let { documentMapper.map(checkNotNull(it) { "Could not update document" }) }
 	}

--- a/src/test/kotlin/org/taktik/icure/asynclogic/objectstorage/IcureObjectStorageTestFsTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/objectstorage/IcureObjectStorageTestFsTest.kt
@@ -181,7 +181,7 @@ fun StringSpec.testObjectSTorageWith(externalServicesProperties: ExternalService
 		}
 		// Task has completed
 		var clientCallCount = 0
-		while (eventsChannel.poll() != null) clientCallCount += 1
+		while (eventsChannel.tryReceive().getOrNull() != null) clientCallCount += 1
 		clientCallCount shouldBe 1
 		// Latest task is upload
 		icureObjectStorage.readAttachment(document1, attachment1).toByteArray(true) shouldContainExactly bytes1

--- a/src/test/kotlin/org/taktik/icure/services/external/rest/shared/controllers/core/DocumentControllerEndToEndTest.kt
+++ b/src/test/kotlin/org/taktik/icure/services/external/rest/shared/controllers/core/DocumentControllerEndToEndTest.kt
@@ -353,4 +353,17 @@ fun <DTO : Any, METADTO : Any> StringSpec.documentControllerSharedEndToEndTests(
 			testUserId
 		).toByteArray(true) shouldContainExactly attachment
 	}
+
+	"Secondary attachment endpoints should not allow to use the main attachment key" {
+		val doc = createDocument(dataFactory.newDocumentNoAttachment()).document
+		shouldRespondErrorStatus(HttpStatus.BAD_REQUEST) {
+			updateSecondaryAttachment(doc.id, doc.mainAttachmentKey, doc.rev, randomSmallAttachment(), emptyList())
+		}
+		shouldRespondErrorStatus(HttpStatus.BAD_REQUEST) {
+			deleteSecondaryAttachment(doc.id, doc.mainAttachmentKey, doc.rev)
+		}
+		shouldRespondErrorStatus(HttpStatus.BAD_REQUEST) {
+			getSecondaryAttachment(doc.id, doc.mainAttachmentKey).toByteArray(true)
+		}
+	}
 }


### PR DESCRIPTION
Prevents unexpected behaviour if the user tries to use the document id as a secondary attachment key