### PR TITLE
EHR-165: put endHour before startHour.

### DIFF
--- a/src/test/kotlin/org/taktik/icure/asynclogic/TimeTableLogicTest.kt
+++ b/src/test/kotlin/org/taktik/icure/asynclogic/TimeTableLogicTest.kt
@@ -344,8 +344,8 @@ class TimeTableLogicTest : StringSpec({
 	"In legacy and rrule version, it should return an empty array if the timeTableItem's startHour is equal or after the endHour - duration" {
 		val legacyCalendarItemTypeId = newId()
 		val rruleCalendarItemTypeId = newId()
-		makeTimeTable(legacyCalendarItemTypeId, agendaId, null, null, listOf("1", "2","3", "4","5","6", "7"), listOf("EVERY_WEEK"),true,100000,101000)
-		makeTimeTable(rruleCalendarItemTypeId, agendaId, "FREQ=DAILY;INTERVAL=1;UNTIL=20321006170000",20200101L, null, null,true,100000,101000)
+		makeTimeTable(legacyCalendarItemTypeId, agendaId, null, null, listOf("1", "2","3", "4","5","6", "7"), listOf("EVERY_WEEK"),true,100000,0)
+		makeTimeTable(rruleCalendarItemTypeId, agendaId, "FREQ=DAILY;INTERVAL=1;UNTIL=20321006170000",20200101L, null, null,true,100000,0)
 		withAuthenticatedHcpContext(hcpId) {
 			val legacy = timeTableLogic.getAvailabilitiesByPeriodAndCalendarItemTypeId(newId(), 20230120102441L, 20240120102441L, legacyCalendarItemTypeId, null, false, true, hcpId).toList()
 			val rrule = timeTableLogic.getAvailabilitiesByPeriodAndCalendarItemTypeId(newId(), 20230120102441L, 20240120102441L, rruleCalendarItemTypeId, null, false, true, hcpId).toList()


### PR DESCRIPTION
As  specified in the test description, put endHour before startHour.