### PR TITLE
MS-9660: kmehr export, exclude private address in createParty

### DIFF
--- a/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/v20161201/KmehrExport.kt
+++ b/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/v20161201/KmehrExport.kt
@@ -135,6 +135,7 @@ import org.taktik.icure.entities.Patient
 import org.taktik.icure.entities.base.Code
 import org.taktik.icure.entities.base.CodeStub
 import org.taktik.icure.entities.embed.Address
+import org.taktik.icure.entities.embed.AddressType as iCureAddressType
 import org.taktik.icure.entities.embed.Content
 import org.taktik.icure.entities.embed.PlanOfAction
 import org.taktik.icure.entities.embed.Service
@@ -190,8 +191,10 @@ open class KmehrExport(
 				}
 			}
 
-			addresses.addAll(makeAddresses(m.addresses))
-			telecoms.addAll(makeTelecoms(m.addresses))
+			val addressesExcludingHome = m.addresses.filter { it.addressType != iCureAddressType.home }
+
+			addresses.addAll(makeAddresses(addressesExcludingHome))
+			telecoms.addAll(makeTelecoms(addressesExcludingHome))
 		}
 	}
 


### PR DESCRIPTION
A doctor's private address and personal cell phone number should not be included in Sumehr, in order to respect his or her privacy.