### PR TITLE
bugfix/MS-10555_Fix-medication-closingDate-sumehr

### DIFF
--- a/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/sumehr/impl/v20161201/SumehrExport.kt
+++ b/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/sumehr/impl/v20161201/SumehrExport.kt
@@ -652,7 +652,7 @@ class SumehrExport(
 			nonConfidentialItems.forEach { m ->
 				val items = trn.headingsAndItemsAndTexts
 				createItemWithContent(
-					m.copy(closingDate = m.closingDate ?: FuzzyValues.getFuzzyDate(LocalDateTime.now().plusMonths(1), ChronoUnit.SECONDS)), items.filter{!(it is HeadingType)}.size + 1, "medication",
+					m.copy(closingDate = getMedicationServiceClosingDate(m)), items.filter{!(it is HeadingType)}.size + 1, "medication",
 					m.content.entries.mapNotNull {
 						makeContent(
 							it.key,


### PR DESCRIPTION
We want to use the date set in medispring in the endMoment of the medicationDTO. Also removed the m.closingDate since it's already used in the getMedicationServiceClosingDate function. Like that we have the correct behavior. Chronic are correctly set as chronic now.